### PR TITLE
Export currents as binary file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ bin/Zc.csv
 bin/fasthenry
 *.csv
 *.DS_Store
+bin/output.bin

--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ bin/Zc.csv
 bin/fasthenry
 *.csv
 *.DS_Store
-bin/output.bin
+bin/Jcurrents.bin

--- a/src/fasthenry/fillM.c
+++ b/src/fasthenry/fillM.c
@@ -4,6 +4,8 @@
 // Enrico
 #include <string.h>
 
+
+
 /* this fills the kircoff's voltage law matrix (Mesh matrix) */
 /* it maps a matrix of mesh currents to branch currents */
 /* it might actually be what some think of as the transpose of M */
@@ -13,6 +15,14 @@
 
 /* much of what is commented out is obsolete stuff from an old idea
    for a preconditioner that never worked */
+
+typedef struct {
+    double x, y, z;       // Filament's starting point
+    double real_xv, real_yv, real_zv; // Real current components
+    double imag_xv, imag_yv, imag_zv; // Imaginary current components
+    double mag_xv, mag_yv, mag_zv;    // Magnitude current components
+} FilamentData;
+   
 void fillM(indsys)
 SYS *indsys;
 {
@@ -631,6 +641,53 @@ int column;
   fclose(fpreal);
   fclose(fpimag);
   fclose(fpmag);
+
+
+
+
+FILE *fpbinary = fopen("output.bin", "wb");
+if (fpbinary == NULL) {
+    perror("Error opening binary file");
+    exit(EXIT_FAILURE);
+}
+
+for (seg = indsys->segment; seg != NULL; seg = seg->next) {
+    for (i = 0; i < seg->num_fils; i++) {
+        fil = &(seg->filaments[i]);
+        current = Ib[fil->filnumber];
+        magcur = cx_abs(current);
+
+        // Calculate components
+        xv = fil->lenvect[XX] / fil->length / fil->area;
+        yv = fil->lenvect[YY] / fil->length / fil->area;
+        zv = fil->lenvect[ZZ] / fil->length / fil->area;
+
+        // Prepare data structure
+        FilamentData data;
+        data.x = fil->x[0];
+        data.y = fil->y[0];
+        data.z = fil->z[0];
+        data.real_xv = xv * current.real;
+        data.real_yv = yv * current.real;
+        data.real_zv = zv * current.real;
+        data.imag_xv = xv * current.imag;
+        data.imag_yv = yv * current.imag;
+        data.imag_zv = zv * current.imag;
+        data.mag_xv = xv * magcur;
+        data.mag_yv = yv * magcur;
+        data.mag_zv = zv * magcur;
+
+        // Write to binary file
+        if (fwrite(&data, sizeof(FilamentData), 1, fpbinary) != 1) {
+            perror("Error writing to binary file");
+            fclose(fpbinary);
+            exit(EXIT_FAILURE);
+        }
+    }
+}
+
+fclose(fpbinary);
+
 
   if (indsys->num_planes == 0)
     return;

--- a/src/fasthenry/fillM.c
+++ b/src/fasthenry/fillM.c
@@ -643,9 +643,9 @@ int column;
   fclose(fpmag);
 
 
+// S Aldhaher export J currents Jreal, Jimag, Jmag as binary
 
-
-FILE *fpbinary = fopen("output.bin", "wb");
+FILE *fpbinary = fopen("Jcurrents.bin", "wb");
 if (fpbinary == NULL) {
     perror("Error opening binary file");
     exit(EXIT_FAILURE);


### PR DESCRIPTION
Currents Jreal, Jimag, Jmag are now exported as binary files. 

Note, the -std=gnu89 flag indicates that the code adheres to the GNU89 standard, which could influence how data types are handled, especially given the differences in standards between older and newer C versions. The -m64 flag suggests a 64-bit architecture, which affects the size of data types.

In a 64-bit environment with the gnu89 standard:

double is likely 8 bytes.
float is 4 bytes.
int is 4 bytes.
Endianness will depend on your system, but most modern systems are little-endian.



Here is a python script to read the binary current file


```
import struct
import csv

# Define the structure format (12 doubles)
# 12 doubles: x, y, z, real_xv, real_yv, real_zv, imag_xv, imag_yv, imag_zv, mag_xv, mag_yv, mag_zv
struct_format = '<12d'  # Little-endian, 12 doubles (8 bytes each)
struct_size = struct.calcsize(struct_format)

binary_file = "C://Git//FastHenry2-Sam//bin//Jcurrents.bin"
csv_file = "C://Git//FastHenry2-Sam//bin//Jcurrents.csv"

try:
    with open(binary_file, "rb") as f, open(csv_file, "w", newline='') as csvfile:
        csv_writer = csv.writer(csvfile)
        
        # Write header row for the CSV file
        csv_writer.writerow(["x", "y", "z", "mag_xv", "mag_yv", "mag_zv"])
        
        while True:
            data = f.read(struct_size)
            if not data:
                break  # End of file

            # Unpack the binary data
            unpacked_data = struct.unpack(struct_format, data)
            x, y, z = unpacked_data[0:3]
            mag_xv, mag_yv, mag_zv = unpacked_data[9:12]

            # Write to CSV
            csv_writer.writerow([x, y, z, mag_xv, mag_yv, mag_zv])

    print(f"Data successfully written to {csv_file}")

except FileNotFoundError:
    print(f"File '{binary_file}' not found.")
except Exception as e:
    print(f"An error occurred: {e}")
```
